### PR TITLE
Changing the provider_id field to be varchar like in ScnSocialAuth

### DIFF
--- a/src/ScnSocialAuthDoctrineORM/Entity/UserProvider.php
+++ b/src/ScnSocialAuthDoctrineORM/Entity/UserProvider.php
@@ -10,7 +10,7 @@ class UserProvider implements UserProviderInterface
     /** @ORM\Id @ORM\Column(type="integer",name="user_id") */
     protected $userId;
 
-    /** @ORM\Id @ORM\Column(type="integer",name="provider_id") */
+    /** @ORM\Id @ORM\Column(type="string",length=50,name="provider_id") */
     protected $providerId;
 
     /** @ORM\Column(type="string") */


### PR DESCRIPTION
Brings this scheme inline with ScnSocialAuth to support long ids. Fixes the issue I posted yesterday on ScnSocialAuth https://github.com/SocalNick/ScnSocialAuth/issues/61
