### PR TITLE
Social-auth requirement dev-master in masterbranch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.3",
         "zendframework/zendframework": "2.*",
-        "socalnick/scn-social-auth": "1.*",
+        "socalnick/scn-social-auth": "dev-master",
         "zf-commons/zfc-user-doctrine-orm": "1.*"
     },
     "autoload": {


### PR DESCRIPTION
Social-Auth dev-master branch is the only one supporting the zfc-user 1.2.*
It's impossible to run zfc-user 1.2.\* with social-auth and social-auth-doctrine-orm at this time.
So either you release a new immediate social-auth release supporting zfc-user 1.2.\* or I need a dev-master branch, where I can fetch the latest stuff and run it on my own.

I hope my explanation made sense to you, otherwise please ping me, my english is not the best ;)
