### PR TITLE
Default entity is toggleable through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@ ScnSocialAuthDoctrineORM
 ========================
 
 An extension of [ScnSocialAuth](https://github.com/SocalNick/ScnSocialAuth) that provides integration with Doctrine2 ORM.
+
+
+Configuration
+-------------
+
+An entity is provided for UserProvider.  Based on the setting of 
+`$config['scn-social-auth']['enable_default_entities']` will the included entity
+be used.  To override the entity use 
+`$config['scn-social-auth']['user_provider_entity_class']`

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,18 +1,5 @@
 <?php
 return array(
-    'doctrine' => array(
-        'driver' => array(
-            'ScnSocialAuth-Entity' => array(
-                'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
-                'paths' => array(__DIR__ . '/../src/ScnSocialAuthDoctrineORM/Entity'),
-            ),
-            'orm_default' => array(
-                'drivers' => array(
-                    'ScnSocialAuthDoctrineORM\Entity'  => 'ScnSocialAuth-Entity'
-                )
-            )
-        )
-    ),
     'service_manager' => array(
         'factories' => array(
             'ScnSocialAuth-ModuleOptions' => 'ScnSocialAuthDoctrineORM\Service\ModuleOptionsFactory',

--- a/src/ScnSocialAuthDoctrineORM/Module.php
+++ b/src/ScnSocialAuthDoctrineORM/Module.php
@@ -3,9 +3,28 @@
 namespace ScnSocialAuthDoctrineORM;
 
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 class Module implements ConfigProviderInterface
 {
+    public function onBootstrap($e)
+    {
+        $app     = $e->getParam('application');
+        $sm      = $app->getServiceManager();
+        $config = $sm->get('Config');
+
+        // Enable default entities
+        if ( ! isset($config['scn-social-auth']['enable_default_entities'])
+            || $config['scn-social-auth']['enable_default_entities']) {
+            $chain = $sm->get('doctrine.driver.orm_default');
+            $chain->addDriver(new AnnotationDriver(
+                new AnnotationReader(),
+                array(__DIR__ . '/Entity')
+            ), 'ScnSocialAuthDoctrineORM\Entity');
+        }
+    }
+
     public function getAutoloaderConfig()
     {
         return array(


### PR DESCRIPTION
Create default entity if configured or no configuration.  If the configuration exists and is false the entity will not be included by default.

zfcuser has enable_default_entities and now this module does too.
